### PR TITLE
Support static bundling of opencv into node-opencv

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ im.line([x1,y1], [x2, y2])
 #### Object Detection
 
 There is a shortcut method for
-[Viola-Jones Haar Cascade](http://www.cognotics.com/opencv/servo_2007_series/part_2/sidebar.html) object
+[Viola-Jones Haar Cascade](http://docs.opencv.org/trunk/d7/d8b/tutorial_py_face_detection.html) object
 detection. This can be used for face detection etc.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Now, take note of current dir, e.g., `/Users/user/Downloads/opencv-2.4.13/macbui
 pwd
 ```
 
-Now, set an environment variable to that path plus `/install`, e.g., `/Users/user/Downloads/opencv-2.4.13/macbuild/install`
+Now, set `OPENCV_DIR` environment variable to that path plus `/install`, e.g., `/Users/user/Downloads/opencv-2.4.13/macbuild/install`
 
 Whenever node-opencv is built, opencv will be bundled in it.

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,7 +24,7 @@
       ],
 
       "libraries": [
-        "<!(node utils/find-opencv.js --libs)"
+        "-L/usr/local/Cellar/opencv/HEAD-19e4c77/lib -L/usr/local/Cellar/opencv/HEAD-19e4c77/share/OpenCV/3rdparty/lib -lopencv_contrib -lopencv_stitching -lopencv_nonfree -lopencv_superres -lopencv_ocl -lopencv_ts -lopencv_videostab -lopencv_gpu -lopencv_photo -lopencv_objdetect -lopencv_legacy -lopencv_video -lopencv_ml -lopencv_calib3d -lopencv_features2d -lopencv_highgui -lIlmImf -llibtiff -llibpng -llibjpeg -lopencv_imgproc -lopencv_flann -lopencv_core -lzlib -framework OpenCL -framework AppKit -framework QuartzCore -framework QTKit -framework Cocoa -lstdc++"
       ],
       # For windows
 
@@ -104,7 +104,7 @@
       ],
 
       "libraries": [
-        "<!(node utils/find-opencv.js --libs)"
+        "-L/usr/local/Cellar/opencv/HEAD-19e4c77/lib -L/usr/local/Cellar/opencv/HEAD-19e4c77/share/OpenCV/3rdparty/lib -lopencv_contrib -lopencv_stitching -lopencv_nonfree -lopencv_superres -lopencv_ocl -lopencv_ts -lopencv_videostab -lopencv_gpu -lopencv_photo -lopencv_objdetect -lopencv_legacy -lopencv_video -lopencv_ml -lopencv_calib3d -lopencv_features2d -lopencv_highgui -lIlmImf -llibtiff -llibpng -llibjpeg -lopencv_imgproc -lopencv_flann -lopencv_core -lzlib -framework OpenCL -framework AppKit -framework QuartzCore -framework QTKit -framework Cocoa -lstdc++"
       ],
       # For windows
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,7 +24,7 @@
       ],
 
       "libraries": [
-        "<!@(node utils/find-opencv.js --libs)"
+        "<!(node utils/find-opencv.js --libs)"
       ],
       # For windows
 
@@ -104,7 +104,7 @@
       ],
 
       "libraries": [
-        "<!@(node utils/find-opencv.js --libs)",
+        "<!(node utils/find-opencv.js --libs)"
       ],
       # For windows
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,7 +24,7 @@
       ],
 
       "libraries": [
-        "-L/usr/local/Cellar/opencv/HEAD-19e4c77/lib -L/usr/local/Cellar/opencv/HEAD-19e4c77/share/OpenCV/3rdparty/lib -lopencv_contrib -lopencv_stitching -lopencv_nonfree -lopencv_superres -lopencv_ocl -lopencv_ts -lopencv_videostab -lopencv_gpu -lopencv_photo -lopencv_objdetect -lopencv_legacy -lopencv_video -lopencv_ml -lopencv_calib3d -lopencv_features2d -lopencv_highgui -lIlmImf -llibtiff -llibpng -llibjpeg -lopencv_imgproc -lopencv_flann -lopencv_core -lzlib -framework OpenCL -framework AppKit -framework QuartzCore -framework QTKit -framework Cocoa -lstdc++"
+        "<!(node utils/find-opencv.js --libs)"
       ],
       # For windows
 
@@ -104,7 +104,7 @@
       ],
 
       "libraries": [
-        "-L/usr/local/Cellar/opencv/HEAD-19e4c77/lib -L/usr/local/Cellar/opencv/HEAD-19e4c77/share/OpenCV/3rdparty/lib -lopencv_contrib -lopencv_stitching -lopencv_nonfree -lopencv_superres -lopencv_ocl -lopencv_ts -lopencv_videostab -lopencv_gpu -lopencv_photo -lopencv_objdetect -lopencv_legacy -lopencv_video -lopencv_ml -lopencv_calib3d -lopencv_features2d -lopencv_highgui -lIlmImf -llibtiff -llibpng -llibjpeg -lopencv_imgproc -lopencv_flann -lopencv_core -lzlib -framework OpenCL -framework AppKit -framework QuartzCore -framework QTKit -framework Cocoa -lstdc++"
+        "<!(node utils/find-opencv.js --libs)"
       ],
       # For windows
 

--- a/src/Contours.cc
+++ b/src/Contours.cc
@@ -115,9 +115,10 @@ NAN_METHOD(Contour::Area) {
 
   Contour *self = Nan::ObjectWrap::Unwrap<Contour>(info.This());
   int pos = info[0]->NumberValue();
+  bool orientation = (info.Length() > 1 && info[1]->BooleanValue());
 
   // info.GetReturnValue().Set(Nan::New<Number>(contourArea(self->contours)));
-  info.GetReturnValue().Set(Nan::New<Number>(contourArea(cv::Mat(self->contours[pos]))));
+  info.GetReturnValue().Set(Nan::New<Number>(contourArea(cv::Mat(self->contours[pos]), orientation)));
 }
 
 NAN_METHOD(Contour::ArcLength) {

--- a/utils/find-opencv.js
+++ b/utils/find-opencv.js
@@ -11,21 +11,21 @@ var flag = process.argv[2] || "--exists";
 var opencv = process.env.PKG_CONFIG_OPENCV3 === "1" ? "opencv3" : '"opencv >= 2.3.1"';
 
 function main(){
-    //Try using pkg-config, but if it fails and it is on Windows, try the fallback
-    exec("pkg-config " + opencv + " " + flag, function(error, stdout, stderr){
-        if(error){
-            if(process.platform === "win32"){
-                fallback();
-            }
-            else{
-                throw new Error("ERROR: failed to run: pkg-config", opencv, flag);
-            }
+    if (process.platform !== "win32") {
+        var path = process.env.OPENCV_DIR;
+        if (path[path.length - 1] === '/') {
+            path = path.substr(0, path.length - 1);
         }
-        else{
-            stdout = stdout.replace(new RegExp('-l-framework', 'g'), '-framework');
-            console.log(stdout);
+
+        if (flag === '--libs') {
+            console.log(`-L${path}/lib -L${path}/share/OpenCV/3rdparty/lib -lopencv_contrib -lopencv_stitching -lopencv_nonfree -lopencv_superres -lopencv_ocl -lopencv_ts -lopencv_videostab -lopencv_gpu -lopencv_photo -lopencv_objdetect -lopencv_legacy -lopencv_video -lopencv_ml -lopencv_calib3d -lopencv_features2d -lopencv_highgui -lIlmImf -llibtiff -llibpng -llibjpeg -lopencv_imgproc -lopencv_flann -lopencv_core -lzlib -framework OpenCL -framework AppKit -framework QuartzCore -framework QTKit -framework Cocoa -lstdc++`);
+        } else if (flag === '--cflags') {
+            console.log(`-I${path}/include/opencv -I${path}/include`);
         }
-    });
+    }
+    else {
+        fallback();
+    }
 }
 
 //======================Windows Specific=======================================
@@ -51,7 +51,7 @@ function printPaths(opencvPath){
         console.log("\"" + opencvPath + "\\..\\..\\include\\opencv\"");
     }
     else if(flag === "--libs") {
-        var libPath = opencvPath + "\\lib\\";
+        var libPath = opencvPath + "\\staticlib\\";
 
         fs.readdir(libPath, function(err, files){
             if(err){
@@ -64,6 +64,7 @@ function printPaths(opencvPath){
                     libs = libs + " \"" + libPath + files[i] + "\" \r\n ";
                 }
             }
+            libs += " \"" + "vfw32.lib" + "\" \r\n ";
             console.log(libs);
         });
     }

--- a/utils/find-opencv.js
+++ b/utils/find-opencv.js
@@ -22,6 +22,7 @@ function main(){
             }
         }
         else{
+            stdout = stdout.replace(new RegExp('-l-framework', 'g'), '-framework');
             console.log(stdout);
         }
     });


### PR DESCRIPTION
This:

1) On windows, uses `staticlib` instead of `lib`
2) On OSX, requires a build of opencv with `BUILD_SHARED_LIBS=OFF`. 
3) Requires `OPENCV_DIR` env variable to be set on osx now, as well as windows